### PR TITLE
test(events): adicionando testes de integração para EventAdminCommandController

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,31 @@
+name: CI Backend - Ludoteca
+
+on:
+  pull_request:
+    branches: [ "main", "develop" ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout do Repositório
+        uses: actions/checkout@v4
+
+      - name: Configurar JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Executar Testes e Gerar Relatório JaCoCo
+        run: mvn clean test -Dspring.profiles.active=test
+        working-directory: ./backend # Diretório mapeado
+
+      - name: Salvar Relatório de Cobertura (Artefato)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-report
+          path: backend/target/site/jacoco/ # Diretório mapeado

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -102,11 +102,35 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.14</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/EventAdminCommandControllerTest.java
+++ b/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/EventAdminCommandControllerTest.java
@@ -1,0 +1,300 @@
+package com.projectLudoteca.ludoteca.command.controller.adminAcess;
+
+import com.projectLudoteca.ludoteca.common.entity.Event;
+import com.projectLudoteca.ludoteca.common.enums.EventStatus;
+import com.projectLudoteca.ludoteca.common.repository.EventRepository;
+import com.projectLudoteca.ludoteca.infrastructure.security.config.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql(scripts = "/data-test.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+public class EventAdminCommandControllerTest {
+
+    // Injetando dependências
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private UUID existingEventId;
+
+    @BeforeEach
+    void setUp() {
+        eventRepository.deleteAll();
+
+        // Criando dados dinâmicos para o teste
+        Event event = new Event();
+        event.setName("Evento Antigo");
+        event.setDescription("Descrição Antiga");
+        event.setStartDate(LocalDateTime.now().plusDays(1));
+        event.setFinalDate(LocalDateTime.now().plusDays(2));
+        event.setStatus(EventStatus.SCHEDULED);
+        event.setStreet("Rua X");
+        event.setNumber("123");
+        event.setNeighborhood("Centro");
+        event.setCity("Cornélio Procópio");
+        event.setState("PR");
+        event.setZipCode("86300-000");
+        event.setHasBoardGames(true);
+        event.setHasRpg(false);
+        event.setHasEscapeRoom(false);
+        event.setRemoved(false);
+
+        event = eventRepository.save(event);
+
+        this.existingEventId = event.getId();
+    }
+
+    // ENDPOINT /register
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnOk_When_CreatingEventAsAdmin() throws Exception {
+
+        String jsonPayload = """
+        {
+          "name": "Novo Evento Criado 2026",
+          "description": "Alguma descrição",
+          "startDate": "2026-05-10T14:00:00",
+          "finalDate": "2026-05-12T18:00:00",
+          "street": "Rua Y",
+          "number": "456",
+          "neighborhood": "Vila Nova",
+          "city": "Cornélio Procópio",
+          "state": "PR",
+          "zipCode": "86300-000",
+          "hasBoardGames": true,
+          "hasRpg": false,
+          "hasEscapeRoom": false,
+          "gamesIds": ["c3b0c531-90fa-4091-a602-bb049e794301"]
+        }
+        """;
+
+        mockMvc.perform(post("/commands/admin/events/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultData").value("Evento cadastrado com Sucesso!"));
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_CreatingEventWithoutToken() throws Exception {
+
+        String jsonPayload = """
+        {
+          "name": "Novo Evento Criado 2026",
+          "description": "Alguma descrição",
+          "startDate": "2026-05-10T14:00:00",
+          "finalDate": "2026-05-12T18:00:00",
+          "street": "Rua Y",
+          "number": "456",
+          "neighborhood": "Vila Nova",
+          "city": "Cornélio Procópio",
+          "state": "PR",
+          "zipCode": "86300-000",
+          "hasBoardGames": true,
+          "hasRpg": false,
+          "hasEscapeRoom": false,
+          "gamesIds": ["c3b0c531-90fa-4091-a602-bb049e794301"]
+        }
+        """;
+
+        mockMvc.perform(post("/commands/admin/events/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void should_ReturnForbidden_When_CreatingEventAsUser() throws Exception {
+
+        String jsonPayload = """
+        {
+          "name": "Novo Evento Criado 2026",
+          "description": "Alguma descrição",
+          "startDate": "2026-05-10T14:00:00",
+          "finalDate": "2026-05-12T18:00:00",
+          "street": "Rua Y",
+          "number": "456",
+          "neighborhood": "Vila Nova",
+          "city": "Cornélio Procópio",
+          "state": "PR",
+          "zipCode": "86300-000",
+          "hasBoardGames": true,
+          "hasRpg": false,
+          "hasEscapeRoom": false,
+          "gamesIds": ["c3b0c531-90fa-4091-a602-bb049e794301"]
+        }
+        """;
+
+        mockMvc.perform(post("/commands/admin/events/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_CreatingEventWithInvalidPayload() throws Exception {
+        String jsonPayload = "{}";
+
+        mockMvc.perform(post("/commands/admin/events/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ENDPOINT /{id}/update
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnOk_When_UpdatingEventAsAdmin() throws Exception {
+
+        String jsonPayload = """
+        {
+            "name": "Evento Atualizado 2026",
+            "hasBoardGames": true,
+            "gamesIds": ["c3b0c531-90fa-4091-a602-bb049e794301"]
+        }
+        """;
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultData").value("Atualização realizada com sucesso!"));
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UpdatingEventWithoutToken() throws Exception {
+        
+        String jsonPayload = """
+        {
+            "name": "Evento Atualizado 2026",
+            "hasBoardGames": true,
+            "gamesIds": ["c3b0c531-90fa-4091-a602-bb049e794301"]
+        }
+        """;
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void should_ReturnForbidden_When_UpdatingEventAsUser() throws Exception {
+
+        String jsonPayload = """
+        {
+            "name": "Evento Atualizado 2026",
+            "hasBoardGames": true,
+            "gamesIds": ["c3b0c531-90fa-4091-a602-bb049e794301"]
+        }
+        """;
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_UpdatingEventWithInvalidPayload() throws Exception {
+        // Testando o @Validated da classe
+        String jsonPayload = "{}";
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ENDPOINT /{id}/start
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnOk_When_StartingEventAsAdmin() throws Exception {
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/start")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultData").value("Evento iniciado com sucesso!"));
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_StartingEventWithoutToken() throws Exception {
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/start")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void should_ReturnForbidden_When_StartingEventAsUser() throws Exception {
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/start")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    // ENDPOINT /{id}/end
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnOk_When_EndingEventAsAdmin() throws Exception {
+        // Deixando o evento em progresso para simular a finalização de um evento
+        Event eventToComplete = eventRepository.findById(existingEventId).orElseThrow();
+        eventToComplete.setStatus(EventStatus.INPROGRESS);
+        eventRepository.save(eventToComplete);
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/end")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultData").value("Evento finalizado com sucesso!"));
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_EndingEventWithoutToken() throws Exception {
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/end")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void should_ReturnForbidden_When_EndingEventAsUser() throws Exception {
+
+        mockMvc.perform(put("/commands/admin/events/" + existingEventId + "/end")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,12 @@
+# URL de conexão do H2 em memória. O 'DB_CLOSE_DELAY=-1' mantém o banco vivo durante a bateria de testes.
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# O Hibernate criará as tabelas do zero baseado nas @Entity e destruirá ao final
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# Desabilita logs extensos em CI
+spring.jpa.show-sql=true

--- a/backend/src/test/resources/data-test.sql
+++ b/backend/src/test/resources/data-test.sql
@@ -1,0 +1,16 @@
+-- Limpando a tabela para evitar lixo se o script rodar duas vezes
+DELETE FROM game_event;
+DELETE FROM game;
+
+-- Inserindo um Jogo Estático
+INSERT INTO game (id, title, description, category, min_players, max_players, is_available, removed)
+VALUES (
+        'c3b0c531-90fa-4091-a602-bb049e794301',
+        'Zombicide',
+        'Jogo de tabuleiro com zumbis',
+        'COOPERATIVE',
+        1,
+        6,
+        true,
+        false
+       );


### PR DESCRIPTION
### 📄 Descrição

Implementa 14 testes abrangendo a camada de segurança, manipulação de estado e validação estrutural (@Validated) para as rotas administrativas de eventos.

### 🔄 Mudanças Realizadas

- [x] Foram adicionados dependências ao pom.xml para:
   - Métrica de Cobertura (JaCoCo), mantida inativa até código legado estiver testado.
   - Persistência volátil de dados (H2 Database Engine), fornecendo dados relacional mantidos somente em memória RAM.

### ✅ Checklist

- [x] Testes necessários foram adicionados.
- [x] Scripts SQL para criação de dados estáticos, necessários nos testes.
- [x] Dados dinâmicos criados, via entidade Event na função `setUp`.
- [x] Arquivo de configuração do banco relacional H2.

### 🔗 Issue Relacionada

Resolves #174 