### PR TITLE
feature: adicionando documentação com swagger

### DIFF
--- a/backend/src/main/java/com/projectLudoteca/ludoteca/command/controller/userAcess/EducationalInstitutionCommandController.java
+++ b/backend/src/main/java/com/projectLudoteca/ludoteca/command/controller/userAcess/EducationalInstitutionCommandController.java
@@ -3,6 +3,8 @@ package com.projectLudoteca.ludoteca.command.controller.userAcess;
 import com.projectLudoteca.ludoteca.command.registerEducationalInstitution.CreateEducationalInstitutionCommand;
 import com.projectLudoteca.ludoteca.command.registerEducationalInstitution.CreateEducationalInstitutionHandler;
 import com.projectLudoteca.ludoteca.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -14,15 +16,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/commands/educational-institutions")
 @Validated
+@Tag(name = "User - Instituições Educacionais", description = "Rotas para cadastro de instituições de ensino")
 public class EducationalInstitutionCommandController {
 
-    private CreateEducationalInstitutionHandler createEducationalInstitutionHandler;
+    private final CreateEducationalInstitutionHandler createEducationalInstitutionHandler;
 
     public EducationalInstitutionCommandController(CreateEducationalInstitutionHandler createEducationalInstitutionHandler) {
         this.createEducationalInstitutionHandler = createEducationalInstitutionHandler;
     }
 
     @PostMapping("/register")
+    @Operation(summary = "Registrar nova instituição", description = "Cria o registro de uma nova instituição educacional no sistema.")
     public ResponseEntity<ApiResponse<String>> createUser(@RequestBody @Validated CreateEducationalInstitutionCommand command) {
         createEducationalInstitutionHandler.handle(command);
 
@@ -30,5 +34,4 @@ public class EducationalInstitutionCommandController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
 }

--- a/backend/src/main/java/com/projectLudoteca/ludoteca/infrastructure/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/projectLudoteca/ludoteca/infrastructure/security/config/SecurityConfig.java
@@ -39,6 +39,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // ✅ Rotas públicas (liberadas)
                         .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
                                 "/auth/**",          // login e register
                                 "/swagger-ui/**",    // documentação
                                 "/v3/api-docs/**",


### PR DESCRIPTION
### 📄 Descrição

Este PR introduz a biblioteca Springdoc OpenAPI (Swagger UI) ao projeto backend. A implementação automatiza a geração da documentação da nossa API REST, fornecendo uma interface gráfica interativa (/swagger-ui.html). Isso é necessário para facilitar o entendimento das rotas, visualização de payloads esperados e testes diretos de integração, auxiliando o time de Frontend e futuros desenvolvedores na exploração dos endpoints disponíveis no sistema.

### 🔄 Mudanças Realizadas

[x] Adição da dependência springdoc-openapi-starter-webmvc-ui no arquivo pom.xml.
[x] Atualização do SecurityConfig.java para liberar acesso público (permitAll()) às rotas do Swagger (/v3/api-docs/, /swagger-ui/, /swagger-ui.html).
[x] Adição das anotações @Operation nos métodos dos Controllers detalhando o propósito de cada rota.

### ✅ Checklist

[ ] Testes foram adicionados ou atualizados. (Deixe desmarcado se não houver testes novos específicos para o Swagger)
[x] Documentação foi atualizada (se necessário).
[x] Revisão de código completa.

### 🔗 Issue Relacionada

Resolves #217 feature implementação de documentação de rotas com swagger