### PR TITLE
test(users): adiciona testes de integracao e corrige retorno do handler

### DIFF
--- a/backend/src/main/java/com/projectLudoteca/ludoteca/command/registerUserAdmin/CreateUserAdminHandler.java
+++ b/backend/src/main/java/com/projectLudoteca/ludoteca/command/registerUserAdmin/CreateUserAdminHandler.java
@@ -7,7 +7,6 @@ import com.projectLudoteca.ludoteca.common.exception.BusinessException;
 import com.projectLudoteca.ludoteca.common.repository.EducationalInstitutionRepository;
 import com.projectLudoteca.ludoteca.common.repository.UserRepository;
 import com.projectLudoteca.ludoteca.common.util.PasswordGenerator;
-import com.projectLudoteca.ludoteca.infrastructure.security.config.JwtService;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
@@ -26,115 +25,47 @@ public class CreateUserAdminHandler {
     private final UserRepository repository;
     private final EducationalInstitutionRepository educationalInstitutionRepository;
     private final PasswordEncoder passwordEncoder;
-    private final JwtService jwtService;
     private final PasswordGenerator passwordGenerator;
     private final JavaMailSender mailSender;
 
     @Autowired
-    public CreateUserAdminHandler(UserRepository repository, EducationalInstitutionRepository educationalInstitutionRepository, PasswordEncoder passwordEncoder, JwtService jwtService, PasswordGenerator passwordGenerator, JavaMailSender mailSender) {
+    public CreateUserAdminHandler(UserRepository repository, EducationalInstitutionRepository educationalInstitutionRepository, PasswordEncoder passwordEncoder, PasswordGenerator passwordGenerator, JavaMailSender mailSender) {
         this.repository = repository;
         this.educationalInstitutionRepository = educationalInstitutionRepository;
         this.passwordEncoder = passwordEncoder;
-        this.jwtService = jwtService;
         this.passwordGenerator = passwordGenerator;
         this.mailSender = mailSender;
     }
 
     @Transactional
     public String handle(CreateUserAdminCommand command) {
-        if (command.name() == null || command.name().trim().isEmpty()) {
-            throw new IllegalArgumentException("O nome é obrigatório.");
-        }
-        if (command.cpf() == null || command.cpf().trim().isEmpty()) {
-            throw new IllegalArgumentException("O CPF é obrigatório.");
-        }
-        if (command.email() == null || command.email().trim().isEmpty()) {
-            throw new IllegalArgumentException("O e-mail é obrigatório.");
-        }
-        if (command.phone() == null || command.phone().trim().isEmpty()) {
-            throw new IllegalArgumentException("O telefone é obrigatório.");
-        }
-        if( command.birthDate() == null ) {
-            throw new IllegalArgumentException("A data de nascimento é obrigatória.");
-        }
-
-        String emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
-        if (!Pattern.matches(emailRegex, command.email())) {
-            throw new IllegalArgumentException("Formato de e-mail inválido.");
-        }
-
-        String phoneRegex = "\\d{10,11}";
-        if (!Pattern.matches(phoneRegex, command.phone())) {
-            throw new IllegalArgumentException("Telefone inválido. Deve conter 10 ou 11 números.");
-        }
-
-        if (command.ra() != null && !command.ra().matches("\\d+")) {
-            throw new BusinessException("400", "O RA deve conter apenas números.");
-        }
+        validateInputs(command);
 
         if (repository.existsByEmail(command.email())) {
-            throw new IllegalArgumentException("E-mail já cadastrado!");
+            throw new BusinessException("400", "E-mail já cadastrado!");
         }
         if (repository.existsByCpf(command.cpf())) {
-            throw new IllegalArgumentException("CPF já cadastrado!");
+            throw new BusinessException("400", "CPF já cadastrado!");
         }
-
-        UserRole role;
-        EducationalInstitution institution = null;
 
         boolean raPresente = command.ra() != null && !command.ra().trim().isEmpty();
         boolean institutionIdPresente = command.institutionId() != null && !command.institutionId().isBlank();
 
         if (raPresente && !institutionIdPresente) {
-            throw new IllegalArgumentException("A Instituição Educacional é obrigatória quando o Registro Acadêmico (RA) é fornecido.");
+            throw new BusinessException("400", "A Instituição Educacional é obrigatória quando o RA é fornecido.");
         }
-
         if (institutionIdPresente && !raPresente) {
-            throw new IllegalArgumentException("O Registro Acadêmico (RA) é obrigatório quando a Instituição Educacional é fornecida.");
+            throw new BusinessException("400", "O RA é obrigatório quando a Instituição Educacional é fornecida.");
+        }
+        if (raPresente && repository.existsByRa(command.ra())) {
+            throw new BusinessException("400", "RA já cadastrado!");
         }
 
-        if (command.userRole() == UserRole.ADMIN) {
-            role = UserRole.ADMIN;
-
-            if (raPresente && repository.existsByRa(command.ra())) {
-                throw new IllegalArgumentException("RA já cadastrado!");
-            }
-
-            if (raPresente) {
-                UUID institutionUuid;
-                try {
-                    institutionUuid = UUID.fromString(command.institutionId());
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException("Formato do ID da instituição inválido.");
-                }
-
-                institution = educationalInstitutionRepository.findById(institutionUuid)
-                        .orElseThrow(() -> new BusinessException("404", "Instituição Educacional não encontrada."));
-            }
-        } else if (raPresente) {
-            role = UserRole.STUDENT;
-
-            if (repository.existsByRa(command.ra())) {
-                throw new IllegalArgumentException("RA já cadastrado!");
-            }
-
-            UUID institutionUuid;
-            try {
-                institutionUuid = UUID.fromString(command.institutionId());
-            } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Formato do ID da instituição inválido.");
-            }
-
-            institution = educationalInstitutionRepository.findById(institutionUuid)
-                    .orElseThrow(() -> new BusinessException("404", "Instituição Educacional não encontrada."));
-        } else {
-            role = UserRole.USER;
-        }
+        UserRole role = command.userRole() != null ? command.userRole() : (raPresente ? UserRole.STUDENT : UserRole.USER);
+        EducationalInstitution institution = raPresente ? fetchEducationalInstitution(command.institutionId(), true) : null;
 
         String password = passwordGenerator.generate();
-
         sendRecoveryEmail(command.email(), password);
-
         String encodedPassword = passwordEncoder.encode(password);
 
         User user = new User();
@@ -150,36 +81,39 @@ public class CreateUserAdminHandler {
 
         repository.save(user);
 
-        String token = jwtService.generateToken(user.getId(), user.getName(),user.getPublicId(), user.getEmail(), user.getUserRole().name());
+        return "Usuário criado com sucesso. Senha enviada por e-mail.";
+    }
 
-        return token;
+    private void validateInputs(CreateUserAdminCommand command) {
+        if (command.name() == null || command.name().trim().isEmpty()) throw new BusinessException("400", "O nome é obrigatório.");
+        if (command.cpf() == null || command.cpf().trim().isEmpty()) throw new BusinessException("400", "O CPF é obrigatório.");
+        if (command.email() == null || command.email().trim().isEmpty()) throw new BusinessException("400", "O e-mail é obrigatório.");
+        if (command.phone() == null || command.phone().trim().isEmpty()) throw new BusinessException("400", "O telefone é obrigatório.");
+        if (command.birthDate() == null) throw new BusinessException("400", "A data de nascimento é obrigatória.");
+
+        if (!Pattern.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$", command.email())) throw new BusinessException("400", "Formato de e-mail inválido.");
+        if (!Pattern.matches("\\d{10,11}", command.phone())) throw new BusinessException("400", "Telefone inválido. Deve conter 10 ou 11 números.");
+        if (command.ra() != null && !command.ra().matches("\\d+")) throw new BusinessException("400", "O RA deve conter apenas números.");
     }
 
     private EducationalInstitution fetchEducationalInstitution(String institutionId, boolean required) {
         if (required && (institutionId == null || institutionId.isBlank())) {
-            throw new IllegalArgumentException("O ID da Instituição Educacional é obrigatório.");
+            throw new BusinessException("400", "O ID da Instituição Educacional é obrigatório.");
         }
+        if (institutionId == null || institutionId.isBlank()) return null;
 
-        if (institutionId == null || institutionId.isBlank()) {
-            return null;
-        }
-
-        UUID institutionUuid;
         try {
-            institutionUuid = UUID.fromString(institutionId);
+            return educationalInstitutionRepository.findById(UUID.fromString(institutionId))
+                    .orElseThrow(() -> new BusinessException("404", "Instituição Educacional não encontrada."));
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Formato do ID da instituição inválido.");
+            throw new BusinessException("400", "Formato do ID da instituição inválido.");
         }
-
-        return educationalInstitutionRepository.findById(institutionUuid)
-                .orElseThrow(() -> new BusinessException("404", "Instituição Educacional não encontrada."));
     }
 
     private void sendRecoveryEmail(String to, String password) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
-
             helper.setTo(to);
             helper.setSubject("Sua Senha - Ludoteca");
             helper.setText("<!DOCTYPE html>\n" +
@@ -283,10 +217,9 @@ public class CreateUserAdminHandler {
                     "</div>\n" +
                     "</body>\n" +
                     "</html>\n", true);
-
             mailSender.send(message);
         } catch (MessagingException e) {
-            throw new RuntimeException("Erro ao enviar e-mail de recuperação.");
+            throw new BusinessException("500", "Erro ao enviar e-mail de recuperação.");
         }
     }
 }

--- a/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/UserAdminCommandControllerTest.java
+++ b/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/UserAdminCommandControllerTest.java
@@ -1,0 +1,148 @@
+package com.projectLudoteca.ludoteca.command.controller.adminAcess;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.projectLudoteca.ludoteca.command.changeRoleUser.ChangeRoleUserCommand;
+import com.projectLudoteca.ludoteca.command.registerUserAdmin.CreateUserAdminCommand;
+import com.projectLudoteca.ludoteca.common.entity.User;
+import com.projectLudoteca.ludoteca.common.enums.UserRole;
+import com.projectLudoteca.ludoteca.common.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.mail.internet.MimeMessage;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = "management.health.mail.enabled=false")
+class UserAdminCommandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private JavaMailSender mailSender;
+
+    private User existingUser;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+
+        // Configura o Mock do Email para não estourar NullPointerException
+        when(mailSender.createMimeMessage()).thenReturn(mock(MimeMessage.class));
+
+        existingUser = new User();
+        existingUser.setName("Usuário Teste Antigo");
+        existingUser.setCpf("00000000000");
+        existingUser.setEmail("antigo@teste.com");
+        existingUser.setPassword("senha123");
+        existingUser.setPhone("11999999999");
+        existingUser.setBirthDate(LocalDate.of(1990, 1, 1));
+        existingUser.setUserRole(UserRole.USER);
+        existingUser = userRepository.save(existingUser);
+    }
+
+    // ENDPOINT /register
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnCreated_AndSaveToDb_When_AdminRegistersUser() throws Exception {
+        CreateUserAdminCommand validCommand = new CreateUserAdminCommand(
+                "Lucas Silva", "12345678909", "lucas@email.com", "11999999999",
+                null, LocalDate.of(2000, 1, 1), UserRole.USER, null
+        );
+
+        mockMvc.perform(post("/commands/admin/users/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validCommand)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.resultData").value("Usuário criado com sucesso. Senha enviada por e-mail."));
+
+        assertTrue(userRepository.existsByEmail("lucas@email.com"));
+    }
+
+    @Test
+    @WithAnonymousUser
+    void should_ReturnUnauthorized_When_AnonymousTriesToRegisterUser() throws Exception {
+        mockMvc.perform(post("/commands/admin/users/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void should_ReturnForbidden_When_CommonUserTriesToRegisterUser() throws Exception {
+        mockMvc.perform(post("/commands/admin/users/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_PayloadIsInvalid() throws Exception {
+        CreateUserAdminCommand invalidCommand = new CreateUserAdminCommand(
+                "Lucas Silva", "12345678909", "email-invalido", "11999999999",
+                null, LocalDate.of(2000, 1, 1), UserRole.USER, null
+        );
+
+        mockMvc.perform(post("/commands/admin/users/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidCommand)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ENDPOINT /{id}/change-role
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnCreated_AndUpdateDb_When_AdminChangesUserRole() throws Exception {
+        ChangeRoleUserCommand command = new ChangeRoleUserCommand(true);
+
+        mockMvc.perform(post("/commands/admin/users/" + existingUser.getId() + "/change-role")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(command)))
+                .andExpect(status().isCreated());
+
+        User updatedUser = userRepository.findById(existingUser.getId()).orElseThrow();
+        assertEquals(UserRole.ADMIN, updatedUser.getUserRole());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void should_ReturnForbidden_When_CommonUserTriesToChangeRole() throws Exception {
+        mockMvc.perform(post("/commands/admin/users/" + existingUser.getId() + "/change-role")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"isAdmin\": true}"))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
### 📄 Descrição

Este PR traz uma refatoração na regra de negócio de criação de usuários e a implementação completa dos testes de integração para as rotas administrativas (`UserAdminCommandController`). 

Aproveitou-se a tarefa para limpar o `CreateUserAdminHandler`, removendo uma brecha que retornava um Token JWT de acesso sempre que o Administrador criava uma conta para outra pessoa. Além disso, as exceções foram padronizadas para `BusinessException` e o código duplicado de validação de papéis foi simplificado. O teste consolida a operação batendo no banco de dados em memória (H2) e validando a serialização exata do objeto `ApiResponse`.

### 🔄 Mudanças Realizadas

- Refatoração do `CreateUserAdminHandler` para retornar apenas uma mensagem de sucesso, eliminando a geração indevida de sessões JWT.
- Remoção de código duplicado e adoção rigorosa do `BusinessException`.
- Implementação dos testes de integração auditando a infraestrutura do Spring MVC e o banco H2.
- Utilização do `@MockitoBean` exclusivamente para contornar o Actuator e evitar o disparo de e-mails reais no ambiente de teste.
- Validação de persistência das entidades, atualização das permissões e formatação estrita do JSON de resposta.

### ✅ Checklist

- [x] Brecha de segurança na geração de Token JWT corrigida.
- [x] Testes de integração implementados cobrindo cenários de sucesso e acessos negados (401/403).
- [x] Validação estrutural do `@Validated` atestada no mapeamento de requisições.
- [x] Todos os testes passando no console local.

### 🔗 Issue Relacionada

Resolves #178 