### PR TITLE
test(loans): adiciona testes unitarios e refatora excecoes globais

### DIFF
--- a/backend/src/main/java/com/projectLudoteca/ludoteca/command/returnedGame/ReturnGameHandler.java
+++ b/backend/src/main/java/com/projectLudoteca/ludoteca/command/returnedGame/ReturnGameHandler.java
@@ -41,10 +41,10 @@ public class ReturnGameHandler {
         }
 
         Game game = gameRepository.findByIdAndRemovedFalse(gameId)
-                .orElseThrow(() -> new RuntimeException("Jogo não encontrado ou removido."));
+                .orElseThrow(() -> new BusinessException("Jogo não encontrado ou removido."));
 
         Loan activeLoan = loanRepository.findByGameIdAndDateReturnIsNullAndRemovedFalse(gameId)
-                .orElseThrow(() -> new RuntimeException("Este jogo não está emprestado no momento."));
+                .orElseThrow(() -> new BusinessException("Este jogo não está emprestado no momento."));
 
         UUID userId = activeLoan.getUserId();
 

--- a/backend/src/main/java/com/projectLudoteca/ludoteca/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/projectLudoteca/ludoteca/common/exception/GlobalExceptionHandler.java
@@ -85,16 +85,27 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * Trata exceções de negócio personalizadas.
+     * Trata exceções de negócio personalizadas, mapeando o código dinamicamente para o HTTP Status.
      */
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException ex) {
+        String codeString = ex.getErrorCode();
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+
+        if (codeString != null) {
+            try {
+                status = HttpStatus.valueOf(Integer.parseInt(codeString));
+            } catch (IllegalArgumentException e) {
+                // Padrão
+            }
+        }
+
         ApiResponse<Void> response = new ApiResponse<>();
-        response.setErrorCode(ex.getErrorCode());
+        response.setErrorCode(codeString != null ? codeString : String.valueOf(status.value()));
         response.setErrorName("BusinessException");
         response.setErrorMessage(ex.getMessage());
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        return ResponseEntity.status(status).body(response);
     }
 
 

--- a/backend/src/test/java/com/projectLudoteca/ludoteca/command/returnedGame/ReturnGameHandlerTest.java
+++ b/backend/src/test/java/com/projectLudoteca/ludoteca/command/returnedGame/ReturnGameHandlerTest.java
@@ -1,0 +1,134 @@
+package com.projectLudoteca.ludoteca.command.returnedGame;
+
+import com.projectLudoteca.ludoteca.common.entity.Game;
+import com.projectLudoteca.ludoteca.common.entity.Loan;
+import com.projectLudoteca.ludoteca.common.entity.User;
+import com.projectLudoteca.ludoteca.common.enums.GameStatus;
+import com.projectLudoteca.ludoteca.common.exception.BusinessException;
+import com.projectLudoteca.ludoteca.common.repository.GameRepository;
+import com.projectLudoteca.ludoteca.common.repository.LoanRepository;
+import com.projectLudoteca.ludoteca.common.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReturnGameHandlerTest {
+
+    @Mock
+    private GameRepository gameRepository;
+    @Mock
+    private LoanRepository loanRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ReturnGameHandler handler;
+
+    private String validGameIdString;
+    private UUID validGameId;
+    private Game dummyGame;
+    private Loan dummyLoan;
+    private User dummyUser;
+
+    @BeforeEach
+    void setUp() {
+        validGameId = UUID.randomUUID();
+        validGameIdString = validGameId.toString();
+
+        dummyGame = new Game();
+        dummyGame.setId(validGameId);
+        dummyGame.setIsAvailable(false);
+
+        dummyUser = new User();
+        dummyUser.setId(UUID.randomUUID());
+        dummyUser.setMinBoardGames(10);
+
+        dummyLoan = new Loan();
+        dummyLoan.setId(UUID.randomUUID());
+        dummyLoan.setUserId(dummyUser.getId());
+        dummyLoan.setGame(dummyGame);
+        dummyLoan.setStatus(GameStatus.BORROWED);
+        dummyLoan.setDateLoan(LocalDateTime.now().minusHours(2));
+    }
+
+    @Test
+    @DisplayName("Deve lançar BusinessException quando o ID for inválido")
+    void should_ThrowException_When_IdIsInvalid() {
+        assertThrows(BusinessException.class, () -> handler.handle("id-invalido-123"));
+
+        verifyNoInteractions(gameRepository, loanRepository, userRepository);
+    }
+
+    @Test
+    @DisplayName("Deve lançar BusinessException quando o jogo não for encontrado")
+    void should_ThrowException_When_GameNotFound() {
+        when(gameRepository.findByIdAndRemovedFalse(validGameId)).thenReturn(Optional.empty());
+
+        assertThrows(BusinessException.class, () -> handler.handle(validGameIdString));
+
+        verifyNoInteractions(loanRepository, userRepository);
+        verify(gameRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve lançar BusinessException quando não houver empréstimo ativo para o jogo")
+    void should_ThrowException_When_ActiveLoanNotFound() {
+        when(gameRepository.findByIdAndRemovedFalse(validGameId)).thenReturn(Optional.of(dummyGame));
+        when(loanRepository.findByGameIdAndDateReturnIsNullAndRemovedFalse(validGameId)).thenReturn(Optional.empty());
+
+        assertThrows(BusinessException.class, () -> handler.handle(validGameIdString));
+
+        verifyNoInteractions(userRepository);
+        verify(loanRepository, never()).save(any());
+        verify(gameRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve lançar BusinessException quando o usuário do empréstimo não for encontrado")
+    void should_ThrowException_When_UserNotFound() {
+        when(gameRepository.findByIdAndRemovedFalse(validGameId)).thenReturn(Optional.of(dummyGame));
+        when(loanRepository.findByGameIdAndDateReturnIsNullAndRemovedFalse(validGameId)).thenReturn(Optional.of(dummyLoan));
+        when(userRepository.findByIdAndRemovedFalse(dummyLoan.getUserId())).thenReturn(Optional.empty());
+
+        assertThrows(BusinessException.class, () -> handler.handle(validGameIdString));
+
+        verify(loanRepository, never()).save(any());
+        verify(gameRepository, never()).save(any());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve realizar a devolução, alterar status e calcular o tempo jogado corretamente")
+    void should_ReturnGameSuccessfully_And_CalculateMinutesPlayed() {
+        when(gameRepository.findByIdAndRemovedFalse(validGameId)).thenReturn(Optional.of(dummyGame));
+        when(loanRepository.findByGameIdAndDateReturnIsNullAndRemovedFalse(validGameId)).thenReturn(Optional.of(dummyLoan));
+        when(userRepository.findByIdAndRemovedFalse(dummyLoan.getUserId())).thenReturn(Optional.of(dummyUser));
+
+        String response = handler.handle(validGameIdString);
+
+        // Asserções de Fluxo e Mutação
+        assertEquals("Jogo devolvido com sucesso.", response);
+        assertTrue(dummyGame.getIsAvailable(), "O jogo deve ficar disponível (true)");
+        assertEquals(GameStatus.RETURNED, dummyLoan.getStatus(), "O status do empréstimo deve ser RETURNED");
+        assertNotNull(dummyLoan.getDateReturn(), "A data de devolução deve ser preenchida");
+        assertEquals(130, dummyUser.getMinBoardGames(), "O tempo jogado deve ser somado corretamente ao histórico do usuário");
+
+        // Asserções de Persistência
+        verify(loanRepository, times(1)).save(dummyLoan);
+        verify(gameRepository, times(1)).save(dummyGame);
+        verify(userRepository, times(1)).save(dummyUser);
+    }
+}


### PR DESCRIPTION
### 📄 Descrição

Este PR traz a cobertura de testes unitários para a regra de negócio de devoluções de jogos (`ReturnGameHandler`) e uma atualização estrutural no tratamento global de exceções.

Aproveitou-se a tarefa para refatorar o handler, substituindo as `RuntimeException` genéricas por `BusinessException`. Para suportar essa mudança adequadamente, o `GlobalExceptionHandler` foi atualizado para ler dinamicamente o código interno da exceção e devolver o status HTTP correspondente, eliminando o engessamento do erro 400. O teste foca em atestar a transição correta de status da devolução e a precisão matemática do motor que calcula o tempo jogado pelo usuário.

### 🔄 Mudanças Realizadas

- Refatoração do `GlobalExceptionHandler` para delegação dinâmica de `HttpStatus` a partir da `BusinessException`.
- Refatoração do `ReturnGameHandler` para padronizar o uso da `BusinessException`.
- Criação da classe de teste unitário `ReturnGameHandlerTest`.
- Mocks configurados para isolar a camada de repositório e focar estritamente na regra de negócio.
- Validação de falhas estruturais, como ID inválido e ausência de entidades no banco.
- Validação da mutação de estado (liberação do jogo e finalização do empréstimo) e verificação do cálculo de minutos jogados.

### ✅ Checklist

- [x] Testes unitários implementados cobrindo os cenários de falha e sucesso.
- [x] Padronização das exceções aplicada no domínio de devolução.
- [x] Delegação dinâmica de status HTTP aplicada no interceptador global.
- [x] Lógica matemática de atribuição de tempo atestada.
- [x] Todos os testes passando no console local.

### 🔗 Issue Relacionada

Resolves #204 