### PR TITLE
test(events): adiciona testes unitarios para a inicializacao de eventos

### DIFF
--- a/backend/src/main/java/com/projectLudoteca/ludoteca/command/startEvent/StartEventHandler.java
+++ b/backend/src/main/java/com/projectLudoteca/ludoteca/command/startEvent/StartEventHandler.java
@@ -1,6 +1,5 @@
 package com.projectLudoteca.ludoteca.command.startEvent;
 
-import ch.qos.logback.core.joran.event.StartEvent;
 import com.projectLudoteca.ludoteca.common.entity.Event;
 import com.projectLudoteca.ludoteca.common.enums.EventStatus;
 import com.projectLudoteca.ludoteca.common.exception.BusinessException;

--- a/backend/src/test/java/com/projectLudoteca/ludoteca/command/startEvent/StartEventHandlerTest.java
+++ b/backend/src/test/java/com/projectLudoteca/ludoteca/command/startEvent/StartEventHandlerTest.java
@@ -1,0 +1,98 @@
+package com.projectLudoteca.ludoteca.command.startEvent;
+
+import com.projectLudoteca.ludoteca.common.entity.Event;
+import com.projectLudoteca.ludoteca.common.enums.EventStatus;
+import com.projectLudoteca.ludoteca.common.exception.BusinessException;
+import com.projectLudoteca.ludoteca.common.repository.EventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StartEventHandlerTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private StartEventHandler handler;
+
+    private String validEventIdString;
+    private UUID validEventId;
+    private Event dummyEvent;
+
+    @BeforeEach
+    void setUp() {
+        validEventId = UUID.randomUUID();
+        validEventIdString = validEventId.toString();
+
+        dummyEvent = new Event();
+        dummyEvent.setId(validEventId);
+    }
+
+    @Test
+    @DisplayName("Deve lançar BusinessException quando o ID for inválido (malformado)")
+    void should_ThrowException_When_IdIsInvalid() {
+        assertThrows(BusinessException.class, () -> handler.handle("id-invalido-123"));
+
+        verifyNoInteractions(eventRepository);
+    }
+
+    @Test
+    @DisplayName("Deve lançar BusinessException quando o evento não for encontrado")
+    void should_ThrowException_When_EventNotFound() {
+        when(eventRepository.findByIdAndRemovedFalse(validEventId)).thenReturn(Optional.empty());
+
+        assertThrows(BusinessException.class, () -> handler.handle(validEventIdString));
+
+        verify(eventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve lançar BusinessException quando o evento já estiver em andamento")
+    void should_ThrowException_When_EventIsAlreadyInProgress() {
+        dummyEvent.setStatus(EventStatus.INPROGRESS);
+        when(eventRepository.findByIdAndRemovedFalse(validEventId)).thenReturn(Optional.of(dummyEvent));
+
+        assertThrows(BusinessException.class, () -> handler.handle(validEventIdString));
+
+        verify(eventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve lançar BusinessException quando o evento já estiver finalizado")
+    void should_ThrowException_When_EventIsCompleted() {
+        dummyEvent.setStatus(EventStatus.COMPLETED);
+        when(eventRepository.findByIdAndRemovedFalse(validEventId)).thenReturn(Optional.of(dummyEvent));
+
+        assertThrows(BusinessException.class, () -> handler.handle(validEventIdString));
+
+        verify(eventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve iniciar o evento com sucesso alterando o status para INPROGRESS")
+    void should_StartEventSuccessfully_When_StatusIsScheduled() {
+        dummyEvent.setStatus(EventStatus.SCHEDULED);
+        when(eventRepository.findByIdAndRemovedFalse(validEventId)).thenReturn(Optional.of(dummyEvent));
+
+        String response = handler.handle(validEventIdString);
+
+        assertEquals("Evento iniciado com sucesso!", response);
+        assertEquals(EventStatus.INPROGRESS, dummyEvent.getStatus());
+
+        verify(eventRepository, times(1)).save(dummyEvent);
+    }
+}


### PR DESCRIPTION
### 📄 Descrição

Este PR entrega a cobertura de testes unitários para a regra de negócio que controla o início dos eventos (`StartEventHandler`).

Aproveitou-se a tarefa para fazer uma rápida limpeza no código, removendo um *import* fantasma provavelmente gerado pela IDE que não estava sendo utilizado. A classe de teste foca especificamente em atestar a integridade da máquina de estados, provando que é impossível burlar o sistema tentando reabrir eventos que já foram concluídos ou iniciar eventos que já estão rodando.

### 🔄 Mudanças Realizadas

- Limpeza de artefatos não utilizados (`ch.qos.logback...`) no cabeçalho do `StartEventHandler`.
- Criação da suite de testes `StartEventHandlerTest` com isolamento total do banco de dados (Mockito).
- Validação estrutural rejeitando *Strings* que não são UUIDs válidos.
- Atestação das travas de segurança do domínio: bloqueio de eventos `INPROGRESS` e `COMPLETED`.
- Validação da transição de estado legítima de agendado para em andamento.

### ✅ Checklist

- [x] Limpeza do código aplicada no Handler.
- [x] Testes unitários implementados cobrindo todas as travas de segurança de status.
- [x] Confirmação exata de interações no repositório (`times(1)` e `never()`).
- [x] Todos os testes passando no console local.

### 🔗 Issue Relacionada

Resolves #205 