### PR TITLE
test(loans): adiciona testes de seguranca e roteamento para emprestimos

### DIFF
--- a/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/LoanAdminCommandControllerTest.java
+++ b/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/LoanAdminCommandControllerTest.java
@@ -1,0 +1,136 @@
+package com.projectLudoteca.ludoteca.command.controller.adminAcess;
+
+import com.projectLudoteca.ludoteca.command.loanGameInEvent.LoanGameInEventHandler;
+import com.projectLudoteca.ludoteca.command.returnedGame.ReturnGameHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class LoanAdminCommandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LoanGameInEventHandler loanGameInEventHandler;
+
+    @MockitoBean
+    private ReturnGameHandler returnGameHandler;
+
+    // ENDPOINT /loan-event
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Deve registrar empréstimo com sucesso quando acessado por um ADMIN")
+    void should_CreateLoanSuccessfully_When_Admin() throws Exception {
+        Mockito.when(loanGameInEventHandler.handle(any())).thenReturn("Jogo emprestado com sucesso!");
+
+        String jsonPayload = """
+        {
+          "userPublicId": "algum-id-publico-123",
+          "gameId": "c3b0c531-90fa-4091-a602-bb049e794301",
+          "eventId": "f4b0c531-90fa-4091-a602-bb049e794302"
+        }
+        """;
+
+        mockMvc.perform(post("/commands/admin/loans/loan-event")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultData").value("Jogo emprestado com sucesso!"));
+    }
+
+    @Test
+    @DisplayName("Deve bloquear registro de empréstimo quando não houver autenticação (Anônimo)")
+    void should_RejectCreateLoan_When_Anonymous() throws Exception {
+        String jsonPayload = """
+        {
+          "userPublicId": "algum-id-publico-123",
+          "gameId": "c3b0c531-90fa-4091-a602-bb049e794301",
+          "eventId": "f4b0c531-90fa-4091-a602-bb049e794302"
+        }
+        """;
+
+        mockMvc.perform(post("/commands/admin/loans/loan-event")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("Deve bloquear registro de empréstimo quando acessado por um usuário comum (USER)")
+    void should_RejectCreateLoan_When_UserRole() throws Exception {
+        String jsonPayload = """
+        {
+          "userPublicId": "algum-id-publico-123",
+          "gameId": "c3b0c531-90fa-4091-a602-bb049e794301",
+          "eventId": "f4b0c531-90fa-4091-a602-bb049e794302"
+        }
+        """;
+
+        mockMvc.perform(post("/commands/admin/loans/loan-event")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Deve barrar requisição de empréstimo por falha estrutural ao enviar corpo vazio")
+    void should_RejectCreateLoan_When_PayloadEmpty() throws Exception {
+        mockMvc.perform(post("/commands/admin/loans/loan-event")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(""))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ENDPOINT /{id}/return-game
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Deve processar devolução com sucesso quando acessado por um ADMIN")
+    void should_ReturnGameSuccessfully_When_Admin() throws Exception {
+        Mockito.when(returnGameHandler.handle(any())).thenReturn("Jogo devolvido com sucesso!");
+
+        mockMvc.perform(post("/commands/admin/loans/" + UUID.randomUUID() + "/return-game")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultData").value("Jogo devolvido com sucesso!"));
+    }
+
+    @Test
+    @DisplayName("Deve bloquear devolução quando não houver autenticação (Anônimo)")
+    void should_RejectReturnGame_When_Anonymous() throws Exception {
+        mockMvc.perform(post("/commands/admin/loans/" + UUID.randomUUID() + "/return-game")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("Deve bloquear devolução quando acessado por um usuário comum (USER)")
+    void should_RejectReturnGame_When_UserRole() throws Exception {
+        mockMvc.perform(post("/commands/admin/loans/" + UUID.randomUUID() + "/return-game")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
### 📄 Descrição

Este PR introduz os testes automatizados para o controlador administrativo de empréstimos (`LoanAdminCommandController`). Como essas rotas alteram diretamente o acervo físico (emprestar e devolver jogos), o foco central desta entrega foi assegurar que as barreiras de segurança e permissão da aplicação são robustas e inquebráveis.

A suíte isola as regras de negócio internas para focar estritamente na validação das requisições, garantindo que o sistema responde adequadamente ao identificar credenciais ausentes, insuficientes ou totalmente válidas, além de barrar pacotes de dados incorretos.

### 🔄 Mudanças Realizadas

- Criação da suíte de testes `LoanAdminCommandControllerTest`.
- Implementação de simulação de contexto de segurança para atestar o comportamento com diferentes níveis de acesso (Administrador e Utilizador Comum).
- Isolamento dos serviços de negócio para focar na validação das requisições e nas respostas HTTP.
- Atestação da barreira que impede acessos não identificados.
- Confirmação de que requisições enviadas com a estrutura vazia são rejeitadas antes de qualquer processamento.

### ✅ Checklist

- [x] O fluxo principal para administradores responde com sucesso.
- [x] Requisições anônimas são rejeitadas.
- [x] Utilizadores sem o nível de privilégio necessário são bloqueados.
- [x] A camada de validação estrutural barra requisições incompletas.
- [x] Todos os testes passaram sem erros no ambiente local.

### 🔗 Issue Relacionada

Resolves #179 