### PR TITLE
test(events): adiciona testes de seguranca e refatora fluxo de participacao

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic",
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/backend/src/main/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/ParticipationEventAdminCommandController.java
+++ b/backend/src/main/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/ParticipationEventAdminCommandController.java
@@ -1,8 +1,7 @@
-package com.projectLudoteca.ludoteca.query.controller.adminAcess;
+package com.projectLudoteca.ludoteca.command.controller.adminAcess;
 
 import com.projectLudoteca.ludoteca.command.registerParticipationEvent.CreateParticipationEventCommand;
 import com.projectLudoteca.ludoteca.command.registerParticipationEvent.CreateParticipationEventHandler;
-import com.projectLudoteca.ludoteca.command.registerUser.CreateUserCommand;
 import com.projectLudoteca.ludoteca.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
@@ -14,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/command/admin/participations-event")
+@RequestMapping("/commands/admin/participations-event")
 public class ParticipationEventAdminCommandController {
 
     private final CreateParticipationEventHandler registerParticipationEventHandler;
@@ -23,7 +22,7 @@ public class ParticipationEventAdminCommandController {
         this.registerParticipationEventHandler = registerParticipationEventHandler;
     }
 
-    @PostMapping("/register-participation-event")
+    @PostMapping("/register")
     @Operation(summary = "Registrar a participação do usuário no evento", description = "Registra a participação do usuário no evento recebendo o id público do usuário e o id do evento")
     public ResponseEntity<ApiResponse<String>> createParticipationEvent(@RequestBody @Validated CreateParticipationEventCommand command) {
 

--- a/backend/src/main/java/com/projectLudoteca/ludoteca/command/registerParticipationEvent/CreateParticipationEventHandler.java
+++ b/backend/src/main/java/com/projectLudoteca/ludoteca/command/registerParticipationEvent/CreateParticipationEventHandler.java
@@ -3,6 +3,7 @@ package com.projectLudoteca.ludoteca.command.registerParticipationEvent;
 import com.projectLudoteca.ludoteca.common.entity.Event;
 import com.projectLudoteca.ludoteca.common.entity.ParticipationEvent;
 import com.projectLudoteca.ludoteca.common.entity.User;
+import com.projectLudoteca.ludoteca.common.exception.BusinessException;
 import com.projectLudoteca.ludoteca.common.repository.EventRepository;
 import com.projectLudoteca.ludoteca.common.repository.ParticipationEventRepository;
 import com.projectLudoteca.ludoteca.common.repository.UserRepository;
@@ -24,13 +25,13 @@ public class CreateParticipationEventHandler {
     public String handle (CreateParticipationEventCommand command) {
 
         User user = userRepository.findByPublicIdAndRemovedFalse(command.userPublicId())
-                .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+                .orElseThrow(() -> new BusinessException("Usuário não encontrado"));
 
         Event event = eventRepository.findByIdAndRemovedFalse(command.eventId())
-                .orElseThrow(() -> new RuntimeException("Evento não encontrado."));
+                .orElseThrow(() -> new BusinessException("Evento não encontrado."));
 
         if (participationEventRepository.existsByEventAndUser(event, user)) {
-            throw new RuntimeException("Presença já registrada para este usuário neste evento.");
+            throw new BusinessException("Presença já registrada para este usuário neste evento.");
         }
 
         ParticipationEvent participation = new ParticipationEvent(event, user);

--- a/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/ParticipationEventAdminCommandControllerTest.java
+++ b/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/ParticipationEventAdminCommandControllerTest.java
@@ -1,0 +1,96 @@
+package com.projectLudoteca.ludoteca.command.controller.adminAcess;
+
+import com.projectLudoteca.ludoteca.command.registerParticipationEvent.CreateParticipationEventHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ParticipationEventAdminCommandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CreateParticipationEventHandler registerParticipationEventHandler;
+
+    // ENDPOINT /register
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Deve registrar a participação com sucesso quando acessado por um ADMIN")
+    void should_ReturnCreated_When_CreatingParticipationAsAdmin() throws Exception {
+        Mockito.when(registerParticipationEventHandler.handle(any())).thenReturn("Participação registrada com sucesso!");
+
+        String jsonPayload = """
+        {
+          "userPublicId": "id-publico-do-usuario-123",
+          "eventId": "f4b0c531-90fa-4091-a602-bb049e794302"
+        }
+        """;
+
+        mockMvc.perform(post("/commands/admin/participations-event/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.resultData").value("Participação registrada com sucesso!"));
+    }
+
+    @Test
+    @DisplayName("Deve bloquear o registro da participação quando não houver autenticação (Anônimo)")
+    void should_ReturnUnauthorized_When_CreatingParticipationWithoutToken() throws Exception {
+        String jsonPayload = """
+        {
+          "userPublicId": "id-publico-do-usuario-123",
+          "eventId": "f4b0c531-90fa-4091-a602-bb049e794302"
+        }
+        """;
+
+        mockMvc.perform(post("/commands/admin/participations-event/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("Deve bloquear o registro da participação quando acessado por um usuário comum (USER)")
+    void should_ReturnForbidden_When_CreatingParticipationAsUser() throws Exception {
+        String jsonPayload = """
+        {
+          "userPublicId": "id-publico-do-usuario-123",
+          "eventId": "f4b0c531-90fa-4091-a602-bb049e794302"
+        }
+        """;
+
+        mockMvc.perform(post("/commands/admin/participations-event/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Deve barrar requisição por falha estrutural ao enviar pacote de dados vazio")
+    void should_ReturnBadRequest_When_CreatingParticipationWithInvalidPayload() throws Exception {
+        mockMvc.perform(post("/commands/admin/participations-event/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(""))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/frontend/web/src/lib/api/commands/events/register-participation-in-event/register-participation-in-event.query.ts
+++ b/frontend/web/src/lib/api/commands/events/register-participation-in-event/register-participation-in-event.query.ts
@@ -12,7 +12,7 @@ export class RegisterParticipationInEventCommand implements ICommand {
 	) {}
 
 	execute(handler: CommandsHandlerService): Observable<AxiosResponse<ICommandResult>> {
-		const url = `${PUBLIC_API_URL}/command/admin/participations-event/register-participation-event`;
+		const url = `${PUBLIC_API_URL}/commands/admin/participations-event/register`;
 		return from(handler.axios.post<ICommandResult>(url, this));
 	}
 }


### PR DESCRIPTION
### 📄 Descrição

Este PR introduz a camada de testes de integração para o controlador administrativo de participações em eventos (`ParticipationEventAdminCommandController`) e realiza um alinhamento arquitetural crítico no domínio. 

O foco desta entrega é garantir que a rota de registro seja impenetrável por usuários sem privilégios e que o fluxo de dados obedeça estritamente aos padrões de resiliência e tratamento de exceções da aplicação.

### 🔄 Mudanças Realizadas

- **Correção de Roteamento:** Ajuste da anotação `@RequestMapping` do Controlador para o padrão plural (`/commands/admin/participations-event`) e endpoint anterior redundante para `/register`, evitando falhas de resolução de rota (404) e alinhando com a convenção do sistema.
- **Padronização de Exceções:** Refatoração do `CreateParticipationEventHandler` para lançar `BusinessException` em vez de `RuntimeException` genéricas, garantindo que o `GlobalExceptionHandler` capture e formate os erros de domínio corretamente.
- **Testes de Segurança (E2E):** Implementação da suíte de testes com simulação de contextos do Spring Security para validar os níveis de acesso (ADMIN, USER e Anônimos).
- **Validação Estrutural:** Inclusão de testes que garantem a rejeição (400 Bad Request) de pacotes com payload vazio.
- **Refatoração:** Alteração de todas as menções do endpoint anterior para `/commands/admin/participations-event/register`, se adequando assim à nova nomenclatura da rota.

### ✅ Checklist

- [x] O registro de participação flui corretamente para administradores.
- [x] O mapeamento do endpoint respeita o padrão da API.
- [x] O Handler utiliza exceções de domínio padronizadas.
- [x] Conexões sem identificação e de usuários comuns são barradas.
- [x] A camada de validação estrutural protege contra envios incorretos.
- [x] Todos os testes passaram localmente.

### 🔗 Issue Relacionada

Resolves #257 