### PR TITLE
test(game): adiciona testes de integração para rotas administrativas

### DIFF
--- a/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/GameAdminCommandControllerTest.java
+++ b/backend/src/test/java/com/projectLudoteca/ludoteca/command/controller/adminAcess/GameAdminCommandControllerTest.java
@@ -1,0 +1,231 @@
+package com.projectLudoteca.ludoteca.command.controller.adminAcess;
+
+import com.projectLudoteca.ludoteca.common.entity.Game;
+import com.projectLudoteca.ludoteca.common.enums.GameCategory;
+import com.projectLudoteca.ludoteca.common.repository.GameRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql(scripts = "/data-test.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+public class GameAdminCommandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    private UUID existingGameId;
+
+    @BeforeEach
+    void setUp() {
+        gameRepository.deleteAll();
+
+        Game game = new Game();
+
+        game.setBarcode(123456);
+        game.setTitle("Jogo Antigo");
+        game.setCategory(GameCategory.STRATEGY);
+        game.setDescription("Descrição Antiga");
+        game.setMinPlayers(2);
+        game.setMaxPlayers(4);
+        game.setIsAvailable(true);
+        game.setLinkInstructionManual("https://manual.com");
+        game.setLinkVideoTutorial("https://video.com");
+        game.setRemoved(false);
+
+        game = gameRepository.save(game);
+
+        this.existingGameId = game.getId();
+    }
+
+    // ENDPOINT /register
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnOk_When_CreatingGameAsAdmin() throws Exception {
+
+        String jsonPayload = """
+                {
+                  "barcode": 987654,
+                  "title": "Catan",
+                  "category": "STRATEGY",
+                  "description": "Jogo de estratégia e negociação",
+                  "minPlayers": 3,
+                  "maxPlayers": 4,
+                  "isAvailable": true,
+                  "linkInstructionManual": "https://manual.com",
+                  "linkVideoTutorial": "https://video.com"
+                }
+                """;
+
+        mockMvc.perform(post("/commands/admin/games/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultData").value("Jogo cadastrado com sucesso!"));
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_CreatingGameWithoutToken() throws Exception {
+
+        String jsonPayload = """
+                {
+                  "barcode": 987654,
+                  "title": "Catan",
+                  "category": "STRATEGY",
+                  "description": "Jogo de estratégia e negociação",
+                  "minPlayers": 3,
+                  "maxPlayers": 4,
+                  "isAvailable": true,
+                  "linkInstructionManual": "https://manual.com",
+                  "linkVideoTutorial": "https://video.com"
+                }
+                """;
+
+        mockMvc.perform(post("/commands/admin/games/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void should_ReturnForbidden_When_CreatingGameAsUser() throws Exception {
+
+        String jsonPayload = """
+                {
+                  "barcode": 987654,
+                  "title": "Catan",
+                  "category": "STRATEGY",
+                  "description": "Jogo de estratégia e negociação",
+                  "minPlayers": 3,
+                  "maxPlayers": 4,
+                  "isAvailable": true,
+                  "linkInstructionManual": "https://manual.com",
+                  "linkVideoTutorial": "https://video.com"
+                }
+                """;
+
+        mockMvc.perform(post("/commands/admin/games/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_CreatingGameWithInvalidPayload() throws Exception {
+
+        String jsonPayload = "{}";
+
+        mockMvc.perform(post("/commands/admin/games/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ENDPOINT /{id}/update
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnOk_When_UpdatingGameAsAdmin() throws Exception {
+
+        String jsonPayload = """
+                {
+                  "barcode": 987654,
+                  "title": "Catan Atualizado",
+                  "category": "STRATEGY",
+                  "description": "Descrição atualizada do jogo",
+                  "minPlayers": 2,
+                  "maxPlayers": 5,
+                  "isAvailable": true,
+                  "linkInstructionManual": "https://manual-atualizado.com",
+                  "linkVideoTutorial": "https://video-atualizado.com"
+                }
+                """;
+
+        mockMvc.perform(put("/commands/admin/games/" + existingGameId + "/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultData").value("Jogo alterado com sucesso!"));
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UpdatingGameWithoutToken() throws Exception {
+
+        String jsonPayload = """
+                {
+                  "barcode": 987654,
+                  "title": "Catan",
+                  "category": "STRATEGY",
+                  "description": "Jogo de estratégia e negociação",
+                  "minPlayers": 3,
+                  "maxPlayers": 4,
+                  "isAvailable": true,
+                  "linkInstructionManual": "https://manual.com",
+                  "linkVideoTutorial": "https://video.com"
+                }
+                """;
+
+        mockMvc.perform(put("/commands/admin/games/" + existingGameId + "/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void should_ReturnForbidden_When_UpdatingGameAsUser() throws Exception {
+
+        String jsonPayload = """
+                {
+                  "barcode": 987654,
+                  "title": "Catan",
+                  "category": "STRATEGY",
+                  "description": "Jogo de estratégia e negociação",
+                  "minPlayers": 3,
+                  "maxPlayers": 4,
+                  "isAvailable": true,
+                  "linkInstructionManual": "https://manual.com",
+                  "linkVideoTutorial": "https://video.com"
+                }
+                """;
+
+        mockMvc.perform(put("/commands/admin/games/" + existingGameId + "/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_UpdatingGameWithInvalidPayload() throws Exception {
+
+        String jsonPayload = "{}";
+
+        mockMvc.perform(put("/commands/admin/games/" + existingGameId + "/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
### 📄 Descrição

Este PR adiciona testes de integração para o GameAdminCommandController, cobrindo as rotas administrativas de cadastro e atualização de jogos.

A implementação valida a blindagem das rotas contra acessos indevidos, diferenciando requisições sem autenticação e usuários autenticados sem privilégio, além de atestar a validação estrutural dos payloads recebidos pelo controller. Os testes utilizam MockMvc, perfil de teste e banco de teste, verificando também as respostas retornadas no padrão ApiResponse.

### 🔄 Mudanças Realizadas

- Implementação dos testes de integração do GameAdminCommandController.
- Cobertura da rota POST /commands/admin/games/register.
- Cobertura da rota PUT /commands/admin/games/{id}/update.
- Validação de acesso ADMIN com retorno 200 OK.
- Validação de requisições sem credenciais com retorno 401 Unauthorized.
- Validação de usuários USER com retorno 403 Forbidden.
- Validação de JSON vazio com retorno 400 Bad Request.
- Criação de registro de jogo em banco de teste para o cenário de atualização.
- Verificação das mensagens retornadas no campo resultData.
- 
### ✅ Checklist

- [x] Testes de sucesso com ADMIN implementados.
- [x] Testes de bloqueio para requisições sem autenticação implementados.
- [x] Testes de bloqueio para usuários sem privilégio implementados.
- [x] Testes de validação estrutural com payload vazio implementados.
- [x] Todos os 8 testes executados com sucesso localmente.
- [x] Build finalizado com sucesso.

### 🔗 Issue Relacionada

Resolves #177