### PR TITLE
test(participation-event): adiciona testes unitários para registro de…

### DIFF
--- a/backend/src/main/java/com/projectLudoteca/ludoteca/command/registerParticipationEvent/CreateParticipationEventHandler.java
+++ b/backend/src/main/java/com/projectLudoteca/ludoteca/command/registerParticipationEvent/CreateParticipationEventHandler.java
@@ -3,6 +3,7 @@ package com.projectLudoteca.ludoteca.command.registerParticipationEvent;
 import com.projectLudoteca.ludoteca.common.entity.Event;
 import com.projectLudoteca.ludoteca.common.entity.ParticipationEvent;
 import com.projectLudoteca.ludoteca.common.entity.User;
+import com.projectLudoteca.ludoteca.common.enums.EventStatus;
 import com.projectLudoteca.ludoteca.common.exception.BusinessException;
 import com.projectLudoteca.ludoteca.common.repository.EventRepository;
 import com.projectLudoteca.ludoteca.common.repository.ParticipationEventRepository;
@@ -16,19 +17,23 @@ public class CreateParticipationEventHandler {
     private final UserRepository userRepository;
     private final EventRepository eventRepository;
 
-    public CreateParticipationEventHandler (ParticipationEventRepository participationEventRepository, UserRepository userRepository, EventRepository eventRepository) {
+    public CreateParticipationEventHandler(ParticipationEventRepository participationEventRepository, UserRepository userRepository, EventRepository eventRepository) {
         this.participationEventRepository = participationEventRepository;
         this.userRepository = userRepository;
         this.eventRepository = eventRepository;
     }
 
-    public String handle (CreateParticipationEventCommand command) {
+    public String handle(CreateParticipationEventCommand command) {
 
         User user = userRepository.findByPublicIdAndRemovedFalse(command.userPublicId())
                 .orElseThrow(() -> new BusinessException("Usuário não encontrado"));
 
         Event event = eventRepository.findByIdAndRemovedFalse(command.eventId())
                 .orElseThrow(() -> new BusinessException("Evento não encontrado."));
+
+        if (!EventStatus.INPROGRESS.equals(event.getStatus())) {
+            throw new BusinessException("O evento não está em andamento para registrar presença.");
+        }
 
         if (participationEventRepository.existsByEventAndUser(event, user)) {
             throw new BusinessException("Presença já registrada para este usuário neste evento.");

--- a/backend/src/test/java/com/projectLudoteca/ludoteca/command/registerParticipationEvent/CreateParticipationEventHandlerTest.java
+++ b/backend/src/test/java/com/projectLudoteca/ludoteca/command/registerParticipationEvent/CreateParticipationEventHandlerTest.java
@@ -1,0 +1,212 @@
+package com.projectLudoteca.ludoteca.command.registerParticipationEvent;
+
+import com.projectLudoteca.ludoteca.common.entity.Event;
+import com.projectLudoteca.ludoteca.common.entity.ParticipationEvent;
+import com.projectLudoteca.ludoteca.common.entity.User;
+import com.projectLudoteca.ludoteca.common.enums.EventStatus;
+import com.projectLudoteca.ludoteca.common.exception.BusinessException;
+import com.projectLudoteca.ludoteca.common.repository.EventRepository;
+import com.projectLudoteca.ludoteca.common.repository.ParticipationEventRepository;
+import com.projectLudoteca.ludoteca.common.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateParticipationEventHandlerTest {
+
+    @Mock
+    private ParticipationEventRepository participationEventRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    private CreateParticipationEventHandler handler;
+
+    private String userPublicId;
+    private UUID eventId;
+    private CreateParticipationEventCommand command;
+
+    @BeforeEach
+    void setUp() {
+        handler = new CreateParticipationEventHandler(
+                participationEventRepository,
+                userRepository,
+                eventRepository
+        );
+
+        userPublicId = UUID.randomUUID().toString();
+        eventId = UUID.randomUUID();
+
+        command = new CreateParticipationEventCommand(userPublicId, eventId);
+    }
+
+    @Test
+    void should_ThrowBusinessException_When_UserNotFound() {
+        when(userRepository.findByPublicIdAndRemovedFalse(userPublicId))
+                .thenReturn(Optional.empty());
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> handler.handle(command)
+        );
+
+        assertEquals("Usuário não encontrado", exception.getMessage());
+
+        verify(userRepository, times(1)).findByPublicIdAndRemovedFalse(userPublicId);
+        verifyNoInteractions(eventRepository);
+        verifyNoInteractions(participationEventRepository);
+    }
+
+    @Test
+    void should_ThrowBusinessException_When_EventNotFound() {
+        User user = new User();
+
+        when(userRepository.findByPublicIdAndRemovedFalse(userPublicId))
+                .thenReturn(Optional.of(user));
+
+        when(eventRepository.findByIdAndRemovedFalse(eventId))
+                .thenReturn(Optional.empty());
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> handler.handle(command)
+        );
+
+        assertEquals("Evento não encontrado.", exception.getMessage());
+
+        verify(userRepository, times(1)).findByPublicIdAndRemovedFalse(userPublicId);
+        verify(eventRepository, times(1)).findByIdAndRemovedFalse(eventId);
+        verifyNoInteractions(participationEventRepository);
+    }
+
+    @Test
+    void should_ThrowBusinessException_When_EventIsScheduled() {
+        User user = new User();
+
+        Event event = new Event();
+        event.setStatus(EventStatus.SCHEDULED);
+
+        when(userRepository.findByPublicIdAndRemovedFalse(userPublicId))
+                .thenReturn(Optional.of(user));
+
+        when(eventRepository.findByIdAndRemovedFalse(eventId))
+                .thenReturn(Optional.of(event));
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> handler.handle(command)
+        );
+
+        assertEquals("O evento não está em andamento para registrar presença.", exception.getMessage());
+
+        verify(userRepository, times(1)).findByPublicIdAndRemovedFalse(userPublicId);
+        verify(eventRepository, times(1)).findByIdAndRemovedFalse(eventId);
+        verify(participationEventRepository, never()).existsByEventAndUser(any(Event.class), any(User.class));
+        verify(participationEventRepository, never()).save(any(ParticipationEvent.class));
+    }
+
+    @Test
+    void should_ThrowBusinessException_When_EventIsCompleted() {
+        User user = new User();
+
+        Event event = new Event();
+        event.setStatus(EventStatus.COMPLETED);
+
+        when(userRepository.findByPublicIdAndRemovedFalse(userPublicId))
+                .thenReturn(Optional.of(user));
+
+        when(eventRepository.findByIdAndRemovedFalse(eventId))
+                .thenReturn(Optional.of(event));
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> handler.handle(command)
+        );
+
+        assertEquals("O evento não está em andamento para registrar presença.", exception.getMessage());
+
+        verify(userRepository, times(1)).findByPublicIdAndRemovedFalse(userPublicId);
+        verify(eventRepository, times(1)).findByIdAndRemovedFalse(eventId);
+        verify(participationEventRepository, never()).existsByEventAndUser(any(Event.class), any(User.class));
+        verify(participationEventRepository, never()).save(any(ParticipationEvent.class));
+    }
+
+    @Test
+    void should_ThrowBusinessException_When_ParticipationAlreadyExists() {
+        User user = new User();
+
+        Event event = new Event();
+        event.setStatus(EventStatus.INPROGRESS);
+
+        when(userRepository.findByPublicIdAndRemovedFalse(userPublicId))
+                .thenReturn(Optional.of(user));
+
+        when(eventRepository.findByIdAndRemovedFalse(eventId))
+                .thenReturn(Optional.of(event));
+
+        when(participationEventRepository.existsByEventAndUser(event, user))
+                .thenReturn(true);
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> handler.handle(command)
+        );
+
+        assertEquals("Presença já registrada para este usuário neste evento.", exception.getMessage());
+
+        verify(userRepository, times(1)).findByPublicIdAndRemovedFalse(userPublicId);
+        verify(eventRepository, times(1)).findByIdAndRemovedFalse(eventId);
+        verify(participationEventRepository, times(1)).existsByEventAndUser(event, user);
+        verify(participationEventRepository, never()).save(any(ParticipationEvent.class));
+    }
+
+    @Test
+    void should_SaveParticipation_When_UserAndEventAreValidAndEventIsInProgress() {
+        User user = new User();
+
+        Event event = new Event();
+        event.setStatus(EventStatus.INPROGRESS);
+
+        when(userRepository.findByPublicIdAndRemovedFalse(userPublicId))
+                .thenReturn(Optional.of(user));
+
+        when(eventRepository.findByIdAndRemovedFalse(eventId))
+                .thenReturn(Optional.of(event));
+
+        when(participationEventRepository.existsByEventAndUser(event, user))
+                .thenReturn(false);
+
+        String result = handler.handle(command);
+
+        assertEquals("Presença registrada com sucesso!", result);
+
+        ArgumentCaptor<ParticipationEvent> participationCaptor =
+                ArgumentCaptor.forClass(ParticipationEvent.class);
+
+        verify(participationEventRepository, times(1))
+                .save(participationCaptor.capture());
+
+        ParticipationEvent participationSaved = participationCaptor.getValue();
+
+        assertNotNull(participationSaved);
+        assertEquals(event, participationSaved.getEvent());
+        assertEquals(user, participationSaved.getUser());
+
+        verify(userRepository, times(1)).findByPublicIdAndRemovedFalse(userPublicId);
+        verify(eventRepository, times(1)).findByIdAndRemovedFalse(eventId);
+        verify(participationEventRepository, times(1)).existsByEventAndUser(event, user);
+    }
+}


### PR DESCRIPTION
### 📄 Descrição

Este PR adiciona testes unitários para o `CreateParticipationEventHandler`, responsável pelo fluxo de registro de presença em eventos.

Além da implementação dos testes, foi realizada uma pequena alteração na regra de negócio do handler para impedir que presenças sejam registradas em eventos que não estejam em andamento. Antes da alteração, o fluxo validava apenas a existência do usuário, a existência do evento e a duplicidade da participação. Dessa forma, ainda era possível registrar presença em eventos com status `SCHEDULED` ou `COMPLETED`.

Com a alteração, o handler passou a validar o `EventStatus` antes de verificar duplicidade e antes de salvar a participação. Agora, o check-in só é permitido quando o evento está com status `INPROGRESS`.

### 🔄 Mudanças Realizadas

- Implementação dos testes unitários para o `CreateParticipationEventHandler`.
- Uso de Mockito para isolar a camada de persistência.
- Validação de usuário inexistente retornando `BusinessException`.
- Validação de evento inexistente retornando `BusinessException`.
- Validação de evento com status `SCHEDULED`, impedindo o registro de presença.
- Validação de evento com status `COMPLETED`, impedindo o registro de presença.
- Validação de presença duplicada retornando `BusinessException`.
- Validação do fluxo de sucesso para evento com status `INPROGRESS`.
- Verificação de que o método `save` não é chamado em fluxos inválidos.
- Verificação de que o método `save` é chamado exatamente uma vez no fluxo válido.
- Ajuste no `CreateParticipationEventHandler` para bloquear check-in em eventos que não estejam em andamento.


### 🛠️ Alteração na Regra de Negócio

Foi adicionada a seguinte validação no `CreateParticipationEventHandler`:

```java
if (!EventStatus.INPROGRESS.equals(event.getStatus())) {
    throw new BusinessException("O evento não está em andamento para registrar presença.");
}
```

Essa alteração garante que o registro de presença só ocorra quando o evento estiver em andamento. Assim, eventos com status `SCHEDULED` ou `COMPLETED` não permitem check-in.

### ✅ Cenários Testados

- Usuário não encontrado.
- Evento não encontrado.
- Evento agendado tentando registrar presença.
- Evento finalizado tentando registrar presença.
- Presença já registrada para o mesmo usuário no mesmo evento.
- Registro de presença realizado com sucesso em evento em andamento.

### ✅ Checklist

- [x] Testes unitários implementados para o registro de presença em eventos.
- [x] Exceções de validação padronizadas com `BusinessException`.
- [x] Validação de usuário não encontrado implementada.
- [x] Validação de evento não encontrado implementada.
- [x] Bloqueio de check-in em eventos agendados implementado.
- [x] Bloqueio de check-in em eventos finalizados implementado.
- [x] Bloqueio de presença duplicada validado.
- [x] Fluxo de sucesso em evento `INPROGRESS` validado.
- [x] Camada de persistência isolada com Mockito.
- [x] Método `save` validado com `never()` nos fluxos inválidos.
- [x] Método `save` validado com `times(1)` no fluxo de sucesso.

### 🔗 Issue Relacionada

Resolves #206